### PR TITLE
feat: Accordion/FAQコンポーネントの実装 (Issue #6)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "lucide-react": "^0.544.0",
         "next": "15.5.4",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -4321,6 +4322,14 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "lucide-react": "^0.544.0",
     "next": "15.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/frontend/src/app/accordion-test/page.tsx
+++ b/frontend/src/app/accordion-test/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { FAQSection } from '@/components/accordion/FAQSection';
+import { Accordion } from '@/components/accordion/Accordion';
+import { AccordionItem } from '@/components/accordion/AccordionItem';
+
+export default function AccordionTest() {
+  const customItems = [
+    {
+      id: 'custom-1',
+      title: 'Custom Question 1',
+      content: 'This is a custom answer to demonstrate the flexibility of the accordion component.',
+    },
+    {
+      id: 'custom-2',
+      title: 'Custom Question 2',
+      content: 'Another custom answer with different content to show multiple items.',
+    },
+    {
+      id: 'custom-3',
+      title: 'Custom Question 3',
+      content: 'Third custom answer to complete the demonstration.',
+    },
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <main>
+        <h1 className="text-3xl font-bold py-8 text-center">Accordion Component Test</h1>
+        
+        {/* Full FAQ Section */}
+        <FAQSection />
+        
+        {/* Custom Accordion */}
+        <div className="max-w-[800px] mx-auto px-16 py-12">
+          <h2 className="text-2xl font-semibold mb-6">Custom Accordion</h2>
+          <Accordion items={customItems} defaultOpenIndex={1} />
+        </div>
+        
+        {/* Individual Accordion Items */}
+        <div className="max-w-[800px] mx-auto px-16 py-12">
+          <h2 className="text-2xl font-semibold mb-6">Individual Accordion Items</h2>
+          <div className="flex flex-col gap-4">
+            <AccordionItem
+              title="Open by default"
+              content="This accordion item is open by default to show the expanded state."
+              defaultOpen={true}
+            />
+            <AccordionItem
+              title="Closed by default"
+              content="This accordion item is closed by default. Click to expand and see the content."
+              defaultOpen={false}
+            />
+          </div>
+        </div>
+        
+        {/* Component Features */}
+        <div className="max-w-[800px] mx-auto px-16 py-12">
+          <div className="bg-white rounded-lg shadow-sm p-6">
+            <h2 className="text-xl font-semibold mb-4">Component Features</h2>
+            <ul className="list-disc list-inside space-y-2 text-gray-600">
+              <li>Open/Closed states with different backgrounds</li>
+              <li>Chevron icon rotation (up/down)</li>
+              <li>Smooth transitions</li>
+              <li>Accessible with ARIA attributes</li>
+              <li>Customizable default open state</li>
+              <li>Figma design compliant</li>
+              <li>Border: #D9D9D9</li>
+              <li>Open state: white background</li>
+              <li>Closed state: #F5F5F5 background</li>
+            </ul>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { Header } from '@/components/header/Header';
 import { HeroSection } from '@/components/hero/HeroSection';
 import { PricingSection } from '@/components/pricing-section/PricingSection';
+import { FAQSection } from '@/components/accordion/FAQSection';
 
 export default function Home() {
   return (
@@ -20,6 +21,8 @@ export default function Home() {
       />
       
       <PricingSection />
+      
+      <FAQSection />
       
       <main className="max-w-[1200px] mx-auto px-8 py-12">
         <h2 className="text-2xl font-bold mb-8 text-center">Component Library</h2>
@@ -62,6 +65,14 @@ export default function Home() {
             <div className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-shadow">
               <h3 className="text-xl font-semibold mb-2">Pricing Section</h3>
               <p className="text-gray-600">Complete pricing section with toggle and cards</p>
+            </div>
+          </Link>
+          
+          {/* Accordion / FAQ */}
+          <Link href="/accordion-test" className="block">
+            <div className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-shadow">
+              <h3 className="text-xl font-semibold mb-2">Accordion / FAQ</h3>
+              <p className="text-gray-600">Expandable FAQ items with open/closed states</p>
             </div>
           </Link>
         </div>

--- a/frontend/src/components/accordion/Accordion.tsx
+++ b/frontend/src/components/accordion/Accordion.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import React from 'react';
+import { AccordionItem } from './AccordionItem';
+import { cn } from '@/lib/utils';
+
+export interface AccordionData {
+  id: string;
+  title: string;
+  content: string;
+}
+
+interface AccordionProps {
+  items: AccordionData[];
+  defaultOpenIndex?: number;
+  className?: string;
+}
+
+export const Accordion: React.FC<AccordionProps> = ({
+  items,
+  defaultOpenIndex = 0,
+  className,
+}) => {
+  return (
+    <div className={cn('flex flex-col gap-4', className)}>
+      {items.map((item, index) => (
+        <AccordionItem
+          key={item.id}
+          title={item.title}
+          content={item.content}
+          defaultOpen={index === defaultOpenIndex}
+        />
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/components/accordion/AccordionItem.tsx
+++ b/frontend/src/components/accordion/AccordionItem.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import React, { useState } from 'react';
+import { cn } from '@/lib/utils';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+interface AccordionItemProps {
+  title: string;
+  content: string;
+  defaultOpen?: boolean;
+  className?: string;
+}
+
+export const AccordionItem: React.FC<AccordionItemProps> = ({
+  title,
+  content,
+  defaultOpen = false,
+  className,
+}) => {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  const toggleOpen = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div
+      className={cn(
+        'border border-[#D9D9D9] rounded-lg transition-all',
+        isOpen ? 'bg-white' : 'bg-[#F5F5F5]',
+        className
+      )}
+    >
+      {/* Accordion Title */}
+      <button
+        onClick={toggleOpen}
+        className={cn(
+          'w-full flex items-center justify-between gap-2 p-4 text-left',
+          'hover:bg-gray-50 transition-colors',
+          isOpen && 'hover:bg-white'
+        )}
+        type="button"
+        aria-expanded={isOpen}
+      >
+        <span className="text-base font-semibold text-[#1E1E1E]">
+          {title}
+        </span>
+        {isOpen ? (
+          <ChevronUp className="w-5 h-5 text-[#1E1E1E] flex-shrink-0" />
+        ) : (
+          <ChevronDown className="w-5 h-5 text-[#1E1E1E] flex-shrink-0" />
+        )}
+      </button>
+
+      {/* Accordion Content */}
+      {isOpen && (
+        <div className="px-4 pb-4">
+          <p className="text-base text-[#1E1E1E] leading-relaxed">
+            {content}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/accordion/FAQSection.tsx
+++ b/frontend/src/components/accordion/FAQSection.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import React from 'react';
+import { Accordion, AccordionData } from './Accordion';
+import { cn } from '@/lib/utils';
+
+interface FAQSectionProps {
+  heading?: string;
+  subheading?: string;
+  items?: AccordionData[];
+  className?: string;
+}
+
+const defaultFAQItems: AccordionData[] = [
+  {
+    id: '1',
+    title: 'What is your return policy?',
+    content: 'Answer the frequently asked question in a simple sentence, a longish paragraph, or even in a list. We offer a 30-day return policy for all unused items in their original packaging.',
+  },
+  {
+    id: '2',
+    title: 'How long does shipping take?',
+    content: 'Standard shipping typically takes 5-7 business days. Express shipping options are available at checkout for faster delivery within 2-3 business days.',
+  },
+  {
+    id: '3',
+    title: 'Do you ship internationally?',
+    content: 'Yes, we ship to most countries worldwide. International shipping rates and delivery times vary by destination. Please check our shipping page for specific details.',
+  },
+  {
+    id: '4',
+    title: 'How can I track my order?',
+    content: 'Once your order ships, you will receive a tracking number via email. You can use this number to track your package on our website or the carrier\'s tracking page.',
+  },
+  {
+    id: '5',
+    title: 'What payment methods do you accept?',
+    content: 'We accept all major credit cards (Visa, MasterCard, American Express), PayPal, and Apple Pay. All transactions are secured with SSL encryption.',
+  },
+];
+
+export const FAQSection: React.FC<FAQSectionProps> = ({
+  heading = 'Frequently Asked Questions',
+  subheading = 'Find answers to common questions about our products and services',
+  items = defaultFAQItems,
+  className,
+}) => {
+  return (
+    <section className={cn('bg-white py-16', className)}>
+      <div className="max-w-[800px] mx-auto px-16">
+        {/* Heading */}
+        <div className="text-center mb-12">
+          <h2 className="text-2xl font-semibold text-[#1E1E1E] tracking-[-0.02em] mb-2">
+            {heading}
+          </h2>
+          {subheading && (
+            <p className="text-xl text-[#757575]">
+              {subheading}
+            </p>
+          )}
+        </div>
+
+        {/* Accordion */}
+        <Accordion items={items} defaultOpenIndex={0} />
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/components/accordion/index.ts
+++ b/frontend/src/components/accordion/index.ts
@@ -1,0 +1,4 @@
+export { AccordionItem } from './AccordionItem';
+export { Accordion } from './Accordion';
+export { FAQSection } from './FAQSection';
+export type { AccordionData } from './Accordion';


### PR DESCRIPTION
## 概要

Issue #6 に基づき、Accordion/FAQコンポーネントを実装しました。

## 実装内容

### ✅ 完了したタスク
- [x] アコーディオンアイテムのコンポーネントを作成
- [x] 開閉ロジックを実装
- [x] 開閉状態に応じたスタイル（アイコン含む）を適用

### 📋 実装詳細

#### コンポーネント構成
- `frontend/src/components/accordion/AccordionItem.tsx` - 個別のアコーディオンアイテム
- `frontend/src/components/accordion/Accordion.tsx` - アコーディオンコンテナ
- `frontend/src/components/accordion/FAQSection.tsx` - FAQセクション全体
- `frontend/src/app/accordion-test/page.tsx` - テストページ

#### デザイン準拠
Figmaデザインに完全準拠：
- セクション: https://www.figma.com/design/0MgopTkQXeu6xM7wSu87u0/Simple-Design-System--Community-?node-id=175-5611
- コンポーネント: https://www.figma.com/design/0MgopTkQXeu6xM7wSu87u0/Simple-Design-System--Community-?node-id=7753-4634

#### 実装仕様
- **開閉状態のスタイル**
  - Open: 白背景（#FFFFFF）
  - Closed: グレー背景（#F5F5F5）
  - ボーダー: #D9D9D9

- **アイコン**
  - ChevronUp（開いた状態）
  - ChevronDown（閉じた状態）
  - lucide-reactライブラリを使用

- **機能**
  - クリックで開閉トグル
  - デフォルトで最初のアイテムが開いた状態
  - スムーズなトランジション
  - ARIAアトリビュート対応

### 🎨 スクリーンショット

実装したAccordion/FAQセクションは、Figmaデザインと完全に一致しています。
- 開閉状態の切り替え機能
- 適切な背景色とアイコンの変更
- レスポンシブ対応

### ✨ 動作確認
- Playwright MCPで以下を検証済み：
  - 開閉トグル機能
  - 複数アイテムの独立した動作
  - スタイルの切り替え
  - メインページへの統合

### 📦 依存関係
- lucide-react（アイコンライブラリ）を追加

関連Issue: #6