### PR TITLE
chore: ホームページからComponent Libraryセクションを削除

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { Header } from '@/components/header/Header';
 import { HeroSection } from '@/components/hero/HeroSection';
 import { PricingSection } from '@/components/pricing-section/PricingSection';
@@ -23,60 +22,6 @@ export default function Home() {
       <PricingSection />
       
       <FAQSection />
-      
-      <main className="max-w-[1200px] mx-auto px-8 py-12">
-        <h2 className="text-2xl font-bold mb-8 text-center">Component Library</h2>
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {/* Button Component */}
-          <Link href="/button-test" className="block">
-            <div className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-shadow">
-              <h3 className="text-xl font-semibold mb-2">Button</h3>
-              <p className="text-gray-600">Primary and Neutral variants with different sizes and states</p>
-            </div>
-          </Link>
-          
-          {/* Header Component */}
-          <Link href="/header-test" className="block">
-            <div className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-shadow">
-              <h3 className="text-xl font-semibold mb-2">Header</h3>
-              <p className="text-gray-600">Navigation header with logo and authentication buttons</p>
-            </div>
-          </Link>
-          
-          {/* Hero Section */}
-          <Link href="/hero-test" className="block">
-            <div className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-shadow">
-              <h3 className="text-xl font-semibold mb-2">Hero Section</h3>
-              <p className="text-gray-600">Hero section with title, subtitle, and alignment options</p>
-            </div>
-          </Link>
-          
-          {/* Pricing Card */}
-          <Link href="/pricing-card-test" className="block">
-            <div className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-shadow">
-              <h3 className="text-xl font-semibold mb-2">Pricing Card</h3>
-              <p className="text-gray-600">Pricing cards with Stroke and Brand variants</p>
-            </div>
-          </Link>
-          
-          {/* Pricing Section */}
-          <Link href="/pricing-section-test" className="block">
-            <div className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-shadow">
-              <h3 className="text-xl font-semibold mb-2">Pricing Section</h3>
-              <p className="text-gray-600">Complete pricing section with toggle and cards</p>
-            </div>
-          </Link>
-          
-          {/* Accordion / FAQ */}
-          <Link href="/accordion-test" className="block">
-            <div className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-shadow">
-              <h3 className="text-xl font-semibold mb-2">Accordion / FAQ</h3>
-              <p className="text-gray-600">Expandable FAQ items with open/closed states</p>
-            </div>
-          </Link>
-        </div>
-      </main>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
ホームページから「Component Library」セクションを完全に削除しました。

## 変更内容
- ✅ Component Libraryのカードグリッド全体を削除
- ✅ 不要になったLinkインポートを削除
- ✅ ページ構成をシンプルに整理

## 現在のホームページ構成
1. Header
2. Hero Section
3. Pricing Section
4. FAQ Section

## 備考
- `/component-library`ページは別PRで作成済み（PR #17）
- 各コンポーネントのテストページ（`/button-test`など）は引き続き有効です
- Footerコンポーネントは別PR（PR #16）で実装中です

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * ホームページを整理し、コンポーネント例のナビゲーショングリッドと関連リンクを削除。主要コンテンツにフォーカスするため、Header／Hero／Pricing／FAQ の各セクションのみを表示し、余分な導線を排除。これにより初回表示がよりシンプルになりました。
* **Chores**
  * 未使用のインポートを削除してコードをクリーンアップ。機能追加や新規コンポーネントの導入はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->